### PR TITLE
Bump GitVersion

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,13 +17,13 @@ jobs:
       run: git fetch --prune --unshallow
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.2
+      uses: gittools/actions/gitversion/setup@v0.9.7
       with:
-        versionSpec: '5.2.x'
+        versionSpec: '5.x'
 
     - name: Execute GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v0.9.2
+      uses: gittools/actions/gitversion/execute@v0.9.7
 
     - name: PHP Setup
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Bump GitVersion actions from version `0.9.3` to `0.9.7` and GitVersion from `5.2.x` to `5.x`. This should fix the `set-env` issues.